### PR TITLE
Fix warning

### DIFF
--- a/phantomjs-shim.js
+++ b/phantomjs-shim.js
@@ -14,7 +14,7 @@ if (!Function.prototype.bind) {
         fToBind = this,
         fNOP    = function() {},
         fBound  = function() {
-          return fToBind.apply(this instanceof fNOP
+          return fToBind.apply(this instanceof Function
                   ? this
                   : oThis,
               aArgs.concat(Array.prototype.slice.call(arguments)));


### PR DESCRIPTION
It was giving the following error:

```
instanceof called on an object with an invalid prototype property
```
